### PR TITLE
Add docker support

### DIFF
--- a/config/site.conf
+++ b/config/site.conf
@@ -1,0 +1,9 @@
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyPass /api http://127.0.0.1:8080/api
+    ProxyPassReverse /api http://127.0.0.1:8080/api
+    ServerName localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+nodaemon=true
+
+[program:apache2]
+command=/usr/sbin/apachectl -DFOREGROUND
+stdout_logfile=/var/log/supervisor/apache2.out
+stderr_logfile=/var/log/supervisor/apache2.err
+
+[program:harvest]
+command=/app/startup.sh
+directory=/app
+startretries=0
+stdout_logfile=/var/log/supervisor/harvest.out
+stderr_logfile=/var/log/supervisor/harvest.err
+
+[program:flask]
+command=python3 /app/io.py
+directory=/app
+stdout_logfile=/var/log/supervisor/flask.out
+stderr_logfile=/var/log/supervisor/flask.err

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		apache2 \
+		cron \
+        awscli \
+        curl \
+        python3 \
+        python3-pip \
+        supervisor && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install \
+	Flask \
+	aws_requests_auth \
+	boto3 \
+	elasticsearch \
+	requests \
+	web3
+
+COPY config/site.conf /etc/apache2/sites-available/search-engine.conf
+COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY *.html /var/www/html/
+COPY css/ /var/www/html/css/
+COPY images/ /var/www/html/images/
+COPY js/ /var/www/html/js/
+COPY python/ /app
+COPY scripts/startup.sh /app/startup.sh
+
+RUN a2dissite 000-default.conf && \
+    a2ensite search-engine.conf && \
+    a2enmod proxy && \
+    a2enmod proxy_http
+
+EXPOSE 80
+CMD supervisord

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# Using docker
+
+The following instructions help you to build docker image with [global_mode](https://github.com/second-state/smart-contract-search-engine/blob/master/documentation/global_mode.md)
+
+1. Get source code
+
+```
+git clone https://github.com/second-state/smart-contract-search-engine.git
+cd smart-contract-search-engine
+```
+
+2. Edit configurations files
+    - ServerName in apache config `config/site.conf`
+    - rpc, elasticsearch configs in `python/config.ini`
+    - IP in `js/secondStateJS.js`
+
+```
+vim config/site.conf
+vim python/config.ini
+vim js/secondStateJS.js
+```
+
+3. Configure `awscli`
+
+```
+aws configure
+```
+
+3. Build docker image
+
+```
+docker build -f docker/Dockerfile -t search-engine .
+```
+
+4. Start docker container
+    - After starting container, supervisord will run startup.sh once and handle apache2 & flask services.
+
+```
+docker run -it --rm -p 8080:80 -v $HOME/.aws:/root/.aws search-engine
+```
+
+Now you can visit `http://<your_host>:8080` to check your smart contract search engine.

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+while true
+do
+  STATUS=$(curl --max-time 30 -s -o /dev/null -w '%{http_code}' https://testnet-rpc.cybermiles.io:8545)
+  if [ $STATUS -eq 200 ]; then
+    nohup /usr/bin/python3.6 harvest.py -m full >/dev/null 2>&1 &
+    nohup /usr/bin/python3.6 harvest.py -m topup >/dev/null 2>&1 &
+    nohup /usr/bin/python3.6 harvest.py -m state >/dev/null 2>&1 &
+    nohup /usr/bin/python3.6 harvest.py -m bytecode >/dev/null 2>&1 &
+    nohup /usr/bin/python3.6 harvest_all.py -m full >/dev/null 2>&1 &
+    nohup /usr/bin/python3.6 harvest_all.py -m topup >/dev/null 2>&1 &
+    break
+  else
+    echo "Got $STATUS please wait"
+  fi
+  sleep 10
+done


### PR DESCRIPTION
I followed [global_mode.md](https://github.com/second-state/smart-contract-search-engine/blob/master/documentation/global_mode.md) instructions and built a docker with apache2 & harvester scripts in it.
This docker image uses supervisord to handle apache & flask api service. The instructions about building and running docker image are in `docker/README.md`.